### PR TITLE
vicky: Task Builder

### DIFF
--- a/vicky/src/bin/vicky/tasks.rs
+++ b/vicky/src/bin/vicky/tasks.rs
@@ -236,17 +236,14 @@ pub async fn tasks_add(
 ) -> Result<Json<RoTask>, AppError> {
     let task_uuid = Uuid::new_v4();
 
-    let task_manifest = Task {
-        id: task_uuid,
-        status: TaskStatus::NEW,
-        locks: task.locks.clone(),
-        display_name: task.display_name.clone(),
-        flake_ref: FlakeRef {
-            flake: task.flake_ref.flake.clone(),
-            args: task.flake_ref.args.clone(),
-        },
-        features: task.features.clone(),
-    };
+    let task_manifest = Task::builder()
+        .with_id(task_uuid)
+        .with_display_name(&task.display_name)
+        .with_flake(&task.flake_ref.flake)
+        .with_flake_args(task.flake_ref.args.clone())
+        .with_locks(task.locks.clone())
+        .requires_features(task.features.clone())
+        .build();
 
     etcd.put_task(&task_manifest).await?;
     global_events.send(GlobalEvent::TaskAdd)?;

--- a/vicky/src/lib/documents/mod.rs
+++ b/vicky/src/lib/documents/mod.rs
@@ -48,6 +48,93 @@ pub struct Task {
     pub features: Vec<String>,
 }
 
+impl Task {
+    pub fn builder() -> TaskBuilder {
+        TaskBuilder::default()
+    }
+}
+
+impl From<TaskBuilder> for Task {
+    fn from(builder: TaskBuilder) -> Self {
+        builder.build()
+    }
+}
+
+pub struct TaskBuilder {
+    id: Option<Uuid>,
+    display_name: Option<String>,
+    status: TaskStatus,
+    locks: Vec<Lock>,
+    flake_ref: FlakeRef,
+    features: Vec<String>
+}
+
+impl Default for TaskBuilder {
+    fn default() -> Self {
+        TaskBuilder {
+            id: None,
+            display_name: None,
+            status: TaskStatus::NEW,
+            locks: Vec::new(),
+            flake_ref: FlakeRef { flake: "".to_string(), args: Vec::new() },
+            features: Vec::new()
+        }
+    }
+}
+
+impl TaskBuilder {
+    pub fn with_id(mut self, id: Uuid) -> Self {
+        self.id = Some(id);
+        self
+    }
+    
+    pub fn with_display_name<S: Into<String>>(mut self, display_name: S) -> Self {
+        self.display_name = Some(display_name.into());
+        self
+    }
+    
+    pub fn with_status(mut self, status: TaskStatus) -> Self {
+        self.status = status;
+        self
+    }
+    
+    pub fn with_read_lock<S: Into<String>>(mut self, name: S) -> Self {
+        self.locks.push(Lock::READ { name: name.into() });
+        self
+    }
+
+    pub fn with_write_lock<S: Into<String>>(mut self, name: S) -> Self {
+        self.locks.push(Lock::WRITE { name: name.into() });
+        self
+    }
+    
+    pub fn with_flake<S: Into<FlakeURI>>(mut self, flake_uri: S) -> Self {
+        self.flake_ref.flake = flake_uri.into();
+        self
+    }
+    
+    pub fn with_flake_arg<S: Into<String>>(mut self, flake_arg: S) -> Self {
+        self.flake_ref.args.push(flake_arg.into());
+        self
+    }
+    
+    pub fn requires_feature<S: Into<String>>(mut self, feature: S) -> Self {
+        self.features.push(feature.into());
+        self
+    }
+    
+    pub fn build(self) -> Task {
+        Task {
+            id: self.id.unwrap_or_else(Uuid::new_v4),
+            display_name: self.display_name.unwrap_or_else(|| "Task".to_string()),
+            features: self.features,
+            status: self.status,
+            locks: self.locks,
+            flake_ref: self.flake_ref
+        }
+    }
+}
+
 #[async_trait]
 pub trait DocumentClient {
     async fn get_all_tasks(&self) -> Result<Vec<Task>, VickyError>;

--- a/vicky/src/lib/documents/mod.rs
+++ b/vicky/src/lib/documents/mod.rs
@@ -132,6 +132,11 @@ impl TaskBuilder {
         self.features.push(feature.into());
         self
     }
+
+    pub fn requires_features(mut self, features: Vec<String>) -> Self {
+        self.features = features;
+        self
+    }
     
     pub fn build(self) -> Task {
         Task {

--- a/vicky/src/lib/documents/mod.rs
+++ b/vicky/src/lib/documents/mod.rs
@@ -108,6 +108,11 @@ impl TaskBuilder {
         self
     }
     
+    pub fn with_locks(mut self, locks: Vec<Lock>) -> Self {
+        self.locks = locks;
+        self
+    }
+    
     pub fn with_flake<S: Into<FlakeURI>>(mut self, flake_uri: S) -> Self {
         self.flake_ref.flake = flake_uri.into();
         self

--- a/vicky/src/lib/documents/mod.rs
+++ b/vicky/src/lib/documents/mod.rs
@@ -138,6 +138,30 @@ impl TaskBuilder {
         self
     }
     
+    pub fn id(&self) -> Option<Uuid> {
+        self.id
+    }
+    
+    pub fn display_name(&self) -> &Option<String> {
+        &self.display_name
+    }
+    
+    pub fn status(&self) -> &TaskStatus {
+        &self.status
+    }
+    
+    pub fn locks(&self) -> &Vec<Lock> {
+        &self.locks
+    }
+    
+    pub fn flake_ref(&self) -> &FlakeRef {
+        &self.flake_ref
+    }
+    
+    pub fn features(&self) -> &Vec<String> {
+        &self.features
+    }
+
     pub fn build(self) -> Task {
         Task {
             id: self.id.unwrap_or_else(Uuid::new_v4),

--- a/vicky/src/lib/documents/mod.rs
+++ b/vicky/src/lib/documents/mod.rs
@@ -66,7 +66,7 @@ pub struct TaskBuilder {
     status: TaskStatus,
     locks: Vec<Lock>,
     flake_ref: FlakeRef,
-    features: Vec<String>
+    features: Vec<String>,
 }
 
 impl Default for TaskBuilder {
@@ -76,8 +76,11 @@ impl Default for TaskBuilder {
             display_name: None,
             status: TaskStatus::NEW,
             locks: Vec::new(),
-            flake_ref: FlakeRef { flake: "".to_string(), args: Vec::new() },
-            features: Vec::new()
+            flake_ref: FlakeRef {
+                flake: "".to_string(),
+                args: Vec::new(),
+            },
+            features: Vec::new(),
         }
     }
 }
@@ -87,17 +90,17 @@ impl TaskBuilder {
         self.id = Some(id);
         self
     }
-    
+
     pub fn with_display_name<S: Into<String>>(mut self, display_name: S) -> Self {
         self.display_name = Some(display_name.into());
         self
     }
-    
+
     pub fn with_status(mut self, status: TaskStatus) -> Self {
         self.status = status;
         self
     }
-    
+
     pub fn with_read_lock<S: Into<String>>(mut self, name: S) -> Self {
         self.locks.push(Lock::READ { name: name.into() });
         self
@@ -107,17 +110,17 @@ impl TaskBuilder {
         self.locks.push(Lock::WRITE { name: name.into() });
         self
     }
-    
+
     pub fn with_locks(mut self, locks: Vec<Lock>) -> Self {
         self.locks = locks;
         self
     }
-    
+
     pub fn with_flake<S: Into<FlakeURI>>(mut self, flake_uri: S) -> Self {
         self.flake_ref.flake = flake_uri.into();
         self
     }
-    
+
     pub fn with_flake_arg<S: Into<String>>(mut self, flake_arg: S) -> Self {
         self.flake_ref.args.push(flake_arg.into());
         self
@@ -127,7 +130,7 @@ impl TaskBuilder {
         self.flake_ref.args = args;
         self
     }
-    
+
     pub fn requires_feature<S: Into<String>>(mut self, feature: S) -> Self {
         self.features.push(feature.into());
         self
@@ -169,7 +172,7 @@ impl TaskBuilder {
             features: self.features,
             status: self.status,
             locks: self.locks,
-            flake_ref: self.flake_ref
+            flake_ref: self.flake_ref,
         }
     }
 }

--- a/vicky/src/lib/documents/mod.rs
+++ b/vicky/src/lib/documents/mod.rs
@@ -122,6 +122,11 @@ impl TaskBuilder {
         self.flake_ref.args.push(flake_arg.into());
         self
     }
+
+    pub fn with_flake_args(mut self, args: Vec<String>) -> Self {
+        self.flake_ref.args = args;
+        self
+    }
     
     pub fn requires_feature<S: Into<String>>(mut self, feature: S) -> Self {
         self.features.push(feature.into());

--- a/vicky/src/lib/vicky/scheduler.rs
+++ b/vicky/src/lib/vicky/scheduler.rs
@@ -148,37 +148,21 @@ impl Scheduler {
 
 #[cfg(test)]
 mod tests {
-    use uuid::Uuid;
-
-    use crate::documents::{FlakeRef, Lock, Task, TaskStatus};
+    use crate::documents::{Task, TaskStatus};
 
     use super::Scheduler;
 
     #[test]
     fn scheduler_creation_no_constraints() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::RUNNING,
-                locks: vec![],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::RUNNING)
+                .build()
         ];
 
         Scheduler::new(tasks, &[]).unwrap();
@@ -187,32 +171,16 @@ mod tests {
     #[test]
     fn scheduler_creation_multiple_read_constraints() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::READ {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::READ {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_read_lock("foo 1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::RUNNING)
+                .with_read_lock("foo 1")
+                .build()
         ];
 
         Scheduler::new(tasks, &[]).unwrap();
@@ -221,32 +189,16 @@ mod tests {
     #[test]
     fn scheduler_creation_single_write_constraints() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo2"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo2")
+                .build()
         ];
 
         Scheduler::new(tasks, &[]).unwrap();
@@ -255,32 +207,16 @@ mod tests {
     #[test]
     fn scheduler_creation_multiple_write_constraints() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo1")
+                .build(),
         ];
 
         let res = Scheduler::new(tasks, &[]);
@@ -290,32 +226,16 @@ mod tests {
     #[test]
     fn scheduler_no_new_task() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::NEW,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::NEW)
+                .with_write_lock("foo1")
+                .build(),
         ];
 
         let res = Scheduler::new(tasks, &[]).unwrap();
@@ -326,32 +246,16 @@ mod tests {
     #[test]
     fn scheduler_new_task() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::NEW,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo2"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::NEW)
+                .with_write_lock("foo2")
+                .build(),
         ];
 
         let res = Scheduler::new(tasks, &[]).unwrap();
@@ -362,32 +266,16 @@ mod tests {
     #[test]
     fn scheduler_new_task_ro() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::READ {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::NEW,
-                locks: vec![Lock::READ {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_read_lock("foo1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::NEW)
+                .with_read_lock("foo1")
+                .build(),
         ];
 
         let res = Scheduler::new(tasks, &[]).unwrap();
@@ -398,32 +286,16 @@ mod tests {
     #[test]
     fn scheduler_new_task_rw_ro() {
         let tasks = vec![
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 1"),
-                status: TaskStatus::RUNNING,
-                locks: vec![Lock::WRITE {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
-            Task {
-                id: Uuid::new_v4(),
-                display_name: String::from("Test 2"),
-                status: TaskStatus::NEW,
-                locks: vec![Lock::READ {
-                    name: String::from("foo1"),
-                }],
-                flake_ref: FlakeRef {
-                    flake: String::from(""),
-                    args: vec![],
-                },
-                features: vec![],
-            },
+            Task::builder()
+                .with_display_name("Test 1")
+                .with_status(TaskStatus::RUNNING)
+                .with_write_lock("foo1")
+                .build(),
+            Task::builder()
+                .with_display_name("Test 2")
+                .with_status(TaskStatus::NEW)
+                .with_read_lock("foo1")
+                .build(),
         ];
 
         let res = Scheduler::new(tasks, &[]).unwrap();


### PR DESCRIPTION
A task builder for tasks to replace:

```rust
Task {
    id: Uuid::new_v4(),
    display_name: String::from("Test 1"),
    status: TaskStatus::NEW,
    locks: vec![Lock::WRITE {
        name: String::from("foo1"),
    }],
    flake_ref: FlakeRef {
        flake: String::from(""),
        args: vec![],
    },
    features: vec![],
},
```

with:

```rust
Task::builder()
    .with_display_name("Test 1")
    .with_write_lock("foo1")
    // has .into() so no .build() is strictly required PROVIDED rust can infer the type, which it sometimes is too stupid to do
```