### PR TITLE
Refactor Constraint Management

### DIFF
--- a/fairy/src/main.rs
+++ b/fairy/src/main.rs
@@ -188,6 +188,7 @@ async fn run_task(cfg: Arc<AppConfig>, task: Task) {
 }
 
 async fn try_claim(cfg: Arc<AppConfig>) -> anyhow::Result<()> {
+    log::debug!("trying to claim task...");
     if let Some(task) = api::<_, Option<Task>>(
         &cfg,
         Method::POST,
@@ -200,6 +201,8 @@ async fn try_claim(cfg: Arc<AppConfig>) -> anyhow::Result<()> {
         log::debug!("{:#?}", task);
 
         tokio::task::spawn(run_task(cfg.clone(), task));
+    } else {
+        log::debug!("no work available...");
     }
 
     Ok(())

--- a/vicky/migrations/2024-05-27-095026_lock_poisoning/down.sql
+++ b/vicky/migrations/2024-05-27-095026_lock_poisoning/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE locks
+DROP poisoned_by_task;

--- a/vicky/migrations/2024-05-27-095026_lock_poisoning/up.sql
+++ b/vicky/migrations/2024-05-27-095026_lock_poisoning/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE locks
+ADD poisoned_by_task uuid;

--- a/vicky/migrations/2024-05-27-095026_lock_poisoning/up.sql
+++ b/vicky/migrations/2024-05-27-095026_lock_poisoning/up.sql
@@ -1,2 +1,7 @@
 ALTER TABLE locks
-ADD poisoned_by_task uuid;
+ADD COLUMN poisoned_by_task uuid;
+
+ALTER TABLE locks
+ADD FOREIGN KEY (poisoned_by_task)
+    REFERENCES tasks(id)
+

--- a/vicky/src/bin/vicky/locks.rs
+++ b/vicky/src/bin/vicky/locks.rs
@@ -1,0 +1,49 @@
+use diesel::PgConnection;
+use rocket::get;
+use rocket::serde::json::Json;
+use vickylib::database::entities::{Database, Lock};
+use vickylib::database::entities::lock::db_impl::LockDatabase;
+use crate::auth::{Machine, User};
+use crate::errors::AppError;
+
+async fn locks_get_poisoned(db: &Database) -> Result<Json<Vec<Lock>>, AppError> {
+    let poisoned_locks: Vec<Lock> = db.run(PgConnection::get_poisoned_locks).await?;
+    Ok(Json(poisoned_locks))
+}
+
+#[get("/poisoned")]
+pub async fn locks_get_poisoned_user(
+    db: Database,
+    _user: User,
+) -> Result<Json<Vec<Lock>>, AppError> {
+    locks_get_poisoned(&db).await
+}
+
+#[get("/poisoned", rank = 2)]
+pub async fn locks_get_poisoned_machine(
+    db: Database,
+    _machine: Machine,
+) -> Result<Json<Vec<Lock>>, AppError> {
+    locks_get_poisoned(&db).await
+}
+
+async fn locks_get_active(db: &Database) -> Result<Json<Vec<Lock>>, AppError> {
+    let locks: Vec<Lock> = db.run(PgConnection::get_active_locks).await?;
+    Ok(Json(locks))
+}
+
+#[get("/active")]
+pub async fn locks_get_active_user(
+    db: Database,
+    _user: User,
+) -> Result<Json<Vec<Lock>>, AppError> {
+    locks_get_active(&db).await
+}
+
+#[get("/active", rank = 2)]
+pub async fn locks_get_active_machine(
+    db: Database,
+    _machine: Machine,
+) -> Result<Json<Vec<Lock>>, AppError> {
+    locks_get_active(&db).await
+}

--- a/vicky/src/bin/vicky/tasks.rs
+++ b/vicky/src/bin/vicky/tasks.rs
@@ -63,15 +63,19 @@ pub async fn tasks_get_machine(
     Ok(Json(tasks))
 }
 
+async fn tasks_specific_get(id: &str, db: &Database) -> Result<Json<Option<Task>>, VickyError> {
+    let task_uuid = Uuid::parse_str(id).unwrap();
+    let tasks: Option<Task> = db.run(move |conn| conn.get_task(task_uuid)).await?;
+    Ok(Json(tasks))
+}
+
 #[get("/<id>")]
 pub async fn tasks_specific_get_user(
     id: String,
     db: Database,
     _user: User,
 ) -> Result<Json<Option<Task>>, VickyError> {
-    let task_uuid = Uuid::parse_str(&id).unwrap();
-    let tasks: Option<Task> = db.run(move |conn| conn.get_task(task_uuid)).await?;
-    Ok(Json(tasks))
+    tasks_specific_get(&id, &db).await
 }
 
 #[get("/<id>", rank = 2)]
@@ -80,9 +84,7 @@ pub async fn tasks_specific_get_machine(
     db: Database,
     _machine: Machine,
 ) -> Result<Json<Option<Task>>, VickyError> {
-    let task_uuid = Uuid::parse_str(&id).unwrap();
-    let tasks: Option<Task> = db.run(move |conn| conn.get_task(task_uuid)).await?;
-    Ok(Json(tasks))
+    tasks_specific_get(&id, &db).await
 }
 
 #[get("/<id>/logs")]

--- a/vicky/src/bin/vicky/tasks.rs
+++ b/vicky/src/bin/vicky/tasks.rs
@@ -183,7 +183,7 @@ pub async fn tasks_claim(
 ) -> Result<Json<Option<Task>>, AppError> {
     let tasks = db.run(|conn| conn.get_all_tasks()).await?;
     let poisoned_locks = db.run(|conn| conn.get_poisoned_locks()).await?;
-    let scheduler = Scheduler::new(tasks, poisoned_locks.as_slice(), &features.features)
+    let scheduler = Scheduler::new(&tasks, &poisoned_locks, &features.features)
         .map_err(|x| VickyError::Scheduler { source: x })?;
     let next_task = scheduler.get_next_task();
 

--- a/vicky/src/lib/database/entities/lock.rs
+++ b/vicky/src/lib/database/entities/lock.rs
@@ -32,6 +32,7 @@ pub mod db_impl {
         pub task_id: Uuid,
         pub name: String,
         pub type_: String,
+        pub poisoned_by_task: Option<Uuid>,
     }
 
     impl DbLock {
@@ -47,12 +48,14 @@ pub mod db_impl {
                     task_id,
                     name: name.clone(),
                     type_: "WRITE".to_string(),
+                    poisoned_by_task: None,
                 },
                 Lock::READ { name } => DbLock {
                     id: None,
                     task_id,
                     name: name.clone(),
                     type_: "READ".to_string(),
+                    poisoned_by_task: None,
                 },
             }
         }

--- a/vicky/src/lib/database/entities/task.rs
+++ b/vicky/src/lib/database/entities/task.rs
@@ -241,7 +241,6 @@ pub mod db_impl {
         fn get_task(&mut self, task_id: Uuid) -> Result<Option<Task>, VickyError>;
         fn put_task(&mut self, task: &Task) -> Result<(), VickyError>;
         fn update_task(&mut self, task: &Task) -> Result<(), VickyError>;
-        fn get_poisoned_locks(&mut self) -> Result<Vec<Lock>, VickyError>;
     }
 
     impl TaskDatabase for diesel::pg::PgConnection {
@@ -346,16 +345,6 @@ pub mod db_impl {
                 .execute(self)?;
 
             Ok(())
-        }
-
-        fn get_poisoned_locks(&mut self) -> Result<Vec<Lock>, VickyError> {
-            use self::locks::dsl::*;
-
-            let poisoned_db_locks: Vec<DbLock> =
-                locks.filter(poisoned_by_task.is_not_null()).load(self)?;
-            let poisoned_locks: Vec<Lock> = poisoned_db_locks.into_iter().map(Lock::from).collect();
-
-            Ok(poisoned_locks)
         }
     }
 }

--- a/vicky/src/lib/database/entities/task.rs
+++ b/vicky/src/lib/database/entities/task.rs
@@ -241,6 +241,7 @@ pub mod db_impl {
         fn get_task(&mut self, task_id: Uuid) -> Result<Option<Task>, VickyError>;
         fn put_task(&mut self, task: &Task) -> Result<(), VickyError>;
         fn update_task(&mut self, task: &Task) -> Result<(), VickyError>;
+        fn get_poisoned_locks(&mut self) -> Result<Vec<Lock>, VickyError>;
     }
 
     impl TaskDatabase for diesel::pg::PgConnection {
@@ -345,6 +346,16 @@ pub mod db_impl {
                 .execute(self)?;
 
             Ok(())
+        }
+
+        fn get_poisoned_locks(&mut self) -> Result<Vec<Lock>, VickyError> {
+            use self::locks::dsl::*;
+
+            let poisoned_db_locks: Vec<DbLock> =
+                locks.filter(poisoned_by_task.is_not_null()).load(self)?;
+            let poisoned_locks: Vec<Lock> = poisoned_db_locks.into_iter().map(Lock::from).collect();
+
+            Ok(poisoned_locks)
         }
     }
 }

--- a/vicky/src/lib/database/entities/task.rs
+++ b/vicky/src/lib/database/entities/task.rs
@@ -89,12 +89,12 @@ impl TaskBuilder {
     }
 
     pub fn with_read_lock<S: Into<String>>(mut self, name: S) -> Self {
-        self.locks.push(Lock::READ { name: name.into() });
+        self.locks.push(Lock::READ { name: name.into(), poisoned: None });
         self
     }
 
     pub fn with_write_lock<S: Into<String>>(mut self, name: S) -> Self {
-        self.locks.push(Lock::WRITE { name: name.into() });
+        self.locks.push(Lock::WRITE { name: name.into(), poisoned: None });
         self
     }
 

--- a/vicky/src/lib/database/schema.rs
+++ b/vicky/src/lib/database/schema.rs
@@ -7,6 +7,7 @@ diesel::table! {
         name -> Varchar,
         #[sql_name = "type"]
         type_ -> Varchar,
+        poisoned_by_task -> Nullable<Uuid>,
     }
 }
 

--- a/vicky/src/lib/errors.rs
+++ b/vicky/src/lib/errors.rs
@@ -14,7 +14,7 @@ pub enum VickyError {
         #[from]
         source: serde_json::Error,
     },
-    
+
     #[error("diesel Error {source:?}")]
     Diesel {
         #[from]
@@ -44,6 +44,8 @@ pub enum VickyError {
 pub enum SchedulerError {
     #[error("Invalid Scheduling")]
     GeneralSchedulingError,
+    #[error("Lock Already Owned")]
+    LockAlreadyOwnedError,
 }
 
 #[derive(Error, Debug)]

--- a/vicky/src/lib/vicky/scheduler.rs
+++ b/vicky/src/lib/vicky/scheduler.rs
@@ -125,7 +125,8 @@ impl<'a> Scheduler<'a> {
         task.locks.iter().all(|lock| {
             self.constraints
                 .get_lock_sum(lock)
-                .map_or(true, |ls| ls.can_add_lock(lock))
+                .map_or(true, |ls| ls.can_add_lock(lock)) &&
+                !self.poisoned_locks.iter().any(|plock| lock.is_conflicting(plock))
         })
     }
 

--- a/vicky/src/lib/vicky/scheduler.rs
+++ b/vicky/src/lib/vicky/scheduler.rs
@@ -307,7 +307,7 @@ mod tests {
                 .build(),
         ];
 
-        let res = Scheduler::new(tasks, &[]).unwrap();
+        let res = Scheduler::new(tasks, &[], &[]).unwrap();
         // Test 1 is currently running and has the write lock
         assert_eq!(res.get_next_task().unwrap().display_name, "Test 2")
     }

--- a/vicky/src/lib/vicky/scheduler.rs
+++ b/vicky/src/lib/vicky/scheduler.rs
@@ -20,8 +20,8 @@ trait ConstraintMgmt {
 impl ConstraintMgmt for Constraints {
     fn get_map_key(lock: &Lock) -> &String {
         match lock {
-            Lock::WRITE { name: object } => object,
-            Lock::READ { name: object } => object,
+            Lock::WRITE { name: object, .. } => object,
+            Lock::READ { name: object, .. } => object,
         }
     }
 
@@ -67,10 +67,10 @@ impl LockSum {
 
     pub fn can_add_lock(&self, lock: &Lock) -> bool {
         match (&self.lock, lock) {
-            (Lock::WRITE { name: _ }, Lock::WRITE { name: _ }) => false,
-            (Lock::WRITE { name: _ }, Lock::READ { name: _ }) => false,
-            (Lock::READ { name: _ }, Lock::WRITE { name: _ }) => false,
-            (Lock::READ { name: object }, Lock::READ { name: object2 }) => object == object2,
+            (Lock::WRITE { .. }, Lock::WRITE { .. }) => false,
+            (Lock::WRITE { .. }, Lock::READ { .. }) => false,
+            (Lock::READ { .. }, Lock::WRITE { .. }) => false,
+            (Lock::READ { name: object, .. }, Lock::READ { name: object2, .. }) => object == object2,
         }
     }
 
@@ -81,7 +81,7 @@ impl LockSum {
         }
 
         match lock {
-            Lock::READ { name: _ } => {
+            Lock::READ { .. } => {
                 self.count += 1;
                 Ok(())
             }

--- a/vickyctl/src/humanize.rs
+++ b/vickyctl/src/humanize.rs
@@ -1,8 +1,22 @@
-use crate::error::Error;
-use crate::AppContext;
-use log::debug;
 use std::io::{ErrorKind, Write};
 use std::process::{Command, Stdio};
+
+use log::debug;
+use which::which;
+
+use crate::AppContext;
+use crate::error::Error;
+
+pub fn ensure_jless(needed_for: &str) -> Result<(), Error> {
+    which("jless")
+        .map_err(|_| {
+            Error::Dependency(
+                "jless".to_string(),
+                format!("the --humanize flag to work with `{needed_for}`"),
+            )
+        })
+        .map(|_| ())
+}
 
 pub fn handle_user_response(ctx: &AppContext, json: &str) -> Result<(), Error> {
     let data: serde_json::Value = serde_json::from_str(json)?;

--- a/vickyctl/src/locks.rs
+++ b/vickyctl/src/locks.rs
@@ -1,0 +1,30 @@
+use crate::{humanize, LocksArgs};
+use crate::error::Error;
+use crate::http_client::prepare_client;
+
+pub fn get_locks_endpoint(locks_args: &LocksArgs) -> &'static str {
+    if locks_args.active {
+        "api/v1/locks/active"
+    } else {
+        "api/v1/locks/poisoned"
+    }
+}
+
+pub fn show_locks(locks_args: &LocksArgs) -> Result<(), Error> {
+    if locks_args.ctx.humanize {
+        humanize::ensure_jless("lock")?;
+    }
+
+    let client = prepare_client(&locks_args.ctx)?;
+    let request = client
+        .get(format!(
+            "{}/{}",
+            locks_args.ctx.vicky_url, get_locks_endpoint(locks_args) 
+        ))
+        .build()?;
+    let response = client.execute(request)?.error_for_status()?;
+
+    let text = response.text()?;
+    humanize::handle_user_response(&locks_args.ctx, &text)?;
+    Ok(())
+}

--- a/vickyctl/src/main.rs
+++ b/vickyctl/src/main.rs
@@ -2,6 +2,7 @@ mod http_client;
 mod humanize;
 mod tasks;
 mod error;
+mod locks;
 
 use crate::tasks::{claim_task, create_task, finish_task};
 use clap::{Args, Parser, Subcommand};
@@ -61,11 +62,23 @@ struct TasksArgs {
     ctx: AppContext,
 }
 
+#[derive(Args, Debug)]
+#[command(version, about = "Show all poisoned locks vicky is managing", long_about = None)]
+struct LocksArgs {
+    #[command(flatten)]
+    ctx: AppContext,
+    #[clap(long)]
+    active: bool,
+    #[clap(long)]
+    poisoned: bool,
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 enum Cli {
     Task(TaskArgs),
     Tasks(TasksArgs),
+    Locks(LocksArgs)
 }
 
 fn main() {
@@ -78,6 +91,7 @@ fn main() {
             TaskCommands::Finish { id, status } => finish_task(&id, &status, &task_args.ctx),
         },
         Cli::Tasks(tasks_args) => tasks::show_tasks(&tasks_args),
+        Cli::Locks(locks_args) => locks::show_locks(&locks_args),
     };
 
     match error {


### PR DESCRIPTION
There were some issues with the constraint management previously that I feel like needed to be addressed.

First of all, counting locks is not a thing that is necessary out of synchronization since two write locks are inherently invalid by nature. It also didn't even take into account the type of lock and just acted on the name which was an absolute waste of processing power.

Call me crazy but I think all that could just be cleaned out, so I replaced it with a scheduler that takes no ownership of the data, due to it relying on a constant state anyways and being consumed just a few lines later in common cases.

This code change should not impact any current as well as future implementation (since the old implementation had more features, but were unusable), but could again be expanded in a better way if needed. Just not with these absurd LockSums.