### PR TITLE
don't run fairy if nix isn't installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+ "which",
 ]
 
 [[package]]

--- a/fairy/Cargo.toml
+++ b/fairy/Cargo.toml
@@ -17,5 +17,8 @@ serde_yaml = "0.9.25"
 tokio = { version = "1.32.0", features = ["rt", "macros", "process"] }
 tokio-util = { version = "0.7.9", features = ["codec"] }
 uuid = { version = "1.4.1", features = ["serde"] }
-rocket = { version="0.5.0", features = ["json", "secrets"] } 
+rocket = { version="0.5.0", features = ["json", "secrets"] }
 which = "6.0.1"
+
+[features]
+nixless-test-mode = []

--- a/fairy/Cargo.toml
+++ b/fairy/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1.32.0", features = ["rt", "macros", "process"] }
 tokio-util = { version = "0.7.9", features = ["codec"] }
 uuid = { version = "1.4.1", features = ["serde"] }
 rocket = { version="0.5.0", features = ["json", "secrets"] } 
+which = "6.0.1"

--- a/fairy/src/main.rs
+++ b/fairy/src/main.rs
@@ -3,7 +3,7 @@ use futures_util::{Sink, StreamExt, TryStreamExt};
 use hyper::{Body, Client, Method, Request};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::process::Stdio;
+use std::process::{exit, Stdio};
 use std::sync::Arc;
 use tokio::process::Command;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use rocket::figment::providers::{Env, Format, Toml};
 use rocket::figment::{Figment, Profile};
+use which::which;
 
 #[derive(Deserialize)]
 pub(crate) struct AppConfig {
@@ -20,10 +21,17 @@ pub(crate) struct AppConfig {
     pub(crate) features: Vec<String>,
 }
 
+const CODE_NIX_NOT_INSTALLED: i32 = 1;
+
 fn main() -> anyhow::Result<()> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Debug)
         .init();
+
+    if which("nix").is_err() {
+        log::error!("\"nix\" binary not found. Please install nix or run on a nix-os host.");
+        exit(CODE_NIX_NOT_INSTALLED);
+    }
 
     log::info!("Fairy starting up.");
 

--- a/fairy/src/main.rs
+++ b/fairy/src/main.rs
@@ -1,16 +1,16 @@
+use std::process::{exit, Stdio};
+use std::sync::Arc;
+
 use anyhow::anyhow;
 use futures_util::{Sink, StreamExt, TryStreamExt};
 use hyper::{Body, Client, Method, Request};
-use serde::de::DeserializeOwned;
+use rocket::figment::{Figment, Profile};
+use rocket::figment::providers::{Env, Format, Toml};
 use serde::{Deserialize, Serialize};
-use std::process::{exit, Stdio};
-use std::sync::Arc;
+use serde::de::DeserializeOwned;
 use tokio::process::Command;
 use tokio_util::codec::{FramedRead, LinesCodec};
 use uuid::Uuid;
-
-use rocket::figment::providers::{Env, Format, Toml};
-use rocket::figment::{Figment, Profile};
 use which::which;
 
 #[derive(Deserialize)]
@@ -23,15 +23,20 @@ pub(crate) struct AppConfig {
 
 const CODE_NIX_NOT_INSTALLED: i32 = 1;
 
+fn ensure_nix() {
+    if which("nix").is_err() {
+        log::error!("\"nix\" binary not found. Please install nix or run on a nix-os host.");
+        exit(CODE_NIX_NOT_INSTALLED);
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Debug)
         .init();
 
-    if which("nix").is_err() {
-        log::error!("\"nix\" binary not found. Please install nix or run on a nix-os host.");
-        exit(CODE_NIX_NOT_INSTALLED);
-    }
+    #[cfg(not(feature = "nixless-test-mode"))]
+    ensure_nix();
 
     log::info!("Fairy starting up.");
 
@@ -178,13 +183,18 @@ async fn try_run_task(cfg: Arc<AppConfig>, task: &Task) -> anyhow::Result<()> {
 }
 
 async fn run_task(cfg: Arc<AppConfig>, task: Task) {
+    #[cfg(not(feature = "nixless-test-mode"))]
     let result = match try_run_task(cfg.clone(), &task).await {
-        Err(e) => {
-            log::info!("task failed: {} {} {:?}", task.id, task.display_name, e);
-            TaskResult::Error
-        }
-        Ok(_) => TaskResult::Success,
-    };
+            Err(e) => {
+                log::info!("task failed: {} {} {:?}", task.id, task.display_name, e);
+                TaskResult::Error
+            }
+            Ok(_) => TaskResult::Success,
+        };
+    
+    #[cfg(feature = "nixless-test-mode")]
+    let result = TaskResult::Success;
+    
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     let _ = api::<_, ()>(
         &cfg,


### PR DESCRIPTION
If nix is not installed on the system then we shouldn't run the fairy to prevent a task from being claimed and then instantly failed since the nix command spawning will panic.

This would just end up spawning a form of zombie fairy that will only poison everything it touches.

I also added a feature flag so it doesn't matter in dev environments and tasks will just automatically succeed as if they were ran.