### PR TITLE
feat: cleaner lock & task datatypes and schemas

### DIFF
--- a/vicky/src/bin/vicky/tasks.rs
+++ b/vicky/src/bin/vicky/tasks.rs
@@ -292,7 +292,6 @@ pub async fn tasks_finish(
         task.locks.iter_mut().for_each(|lock| lock.poison(&task.id));
     }
 
-    // TODO: this clone is weird and can be saved I think
     let task2 = task.clone();
     db.run(move |conn| conn.update_task(&task2)).await?;
     global_events.send(GlobalEvent::TaskUpdate { uuid: task.id })?;

--- a/vicky/src/lib/database/entities/mod.rs
+++ b/vicky/src/lib/database/entities/mod.rs
@@ -2,7 +2,7 @@ pub mod lock;
 pub mod task;
 pub mod user;
 
-pub use lock::Lock;
+pub use lock::{Lock, LockKind};
 use rocket_sync_db_pools::database;
 pub use task::Task;
 

--- a/vicky/src/lib/database/entities/task.rs
+++ b/vicky/src/lib/database/entities/task.rs
@@ -7,7 +7,7 @@ use chrono::{NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(tag = "result", rename_all = "UPPERCASE")]
 pub enum TaskResult {
     Success,
@@ -100,18 +100,12 @@ impl TaskBuilder {
     }
 
     pub fn with_read_lock<S: Into<String>>(mut self, name: S) -> Self {
-        self.locks.push(Lock::Read {
-            name: name.into(),
-            poisoned: None,
-        });
+        self.locks.push(Lock::read(name));
         self
     }
 
     pub fn with_write_lock<S: Into<String>>(mut self, name: S) -> Self {
-        self.locks.push(Lock::Write {
-            name: name.into(),
-            poisoned: None,
-        });
+        self.locks.push(Lock::write(name));
         self
     }
 
@@ -217,7 +211,7 @@ pub mod db_impl {
     use std::fmt::Display;
     use uuid::Uuid;
     // these here are evil >:(
-    use crate::database::entities::lock::db_impl::DbLock;
+    use crate::database::entities::lock::db_impl::{DbLock, NewDbLock};
     use crate::database::schema::locks;
     use crate::database::schema::tasks;
     use itertools::Itertools;
@@ -348,22 +342,19 @@ pub mod db_impl {
 
         fn put_task(&mut self, task: Task) -> Result<(), VickyError> {
             self.transaction(|conn| {
-                let db_locks: Vec<DbLock> = task
+                let db_locks: Vec<NewDbLock> = task
                     .locks
                     .iter()
-                    .map(|l| DbLock::from_lock(l, task.id))
+                    .map(|l| NewDbLock::from_lock(l, task.id))
                     .collect();
                 let db_task: DbTask = task.into();
 
                 diesel::insert_into(tasks::table)
                     .values(db_task)
                     .execute(conn)?;
-                for mut db_lock in db_locks {
-                    db_lock.id = None;
-                    diesel::insert_into(locks::table)
-                        .values(db_lock)
-                        .execute(conn)?;
-                }
+                diesel::insert_into(locks::table)
+                    .values(db_locks)
+                    .execute(conn)?;
                 Ok(())
             })
         }

--- a/vicky/src/lib/database/schema.rs
+++ b/vicky/src/lib/database/schema.rs
@@ -2,11 +2,11 @@
 
 diesel::table! {
     locks (id) {
-        id -> Nullable<Uuid>,
+        id -> Uuid,
         task_id -> Uuid,
         name -> Varchar,
         #[sql_name = "type"]
-        type_ -> Varchar,
+        lock_type -> Varchar,
         poisoned_by_task -> Nullable<Uuid>,
     }
 }

--- a/vicky/src/lib/vicky/scheduler.rs
+++ b/vicky/src/lib/vicky/scheduler.rs
@@ -320,10 +320,9 @@ mod tests {
             .with_display_name("I need to do something")
             .with_write_lock("Entire Prod Cluster")
             .build()];
-        let poisoned_locks = vec![Lock::Write {
-            name: "Entire Prod Cluster".to_string(),
-            poisoned: Some(Uuid::new_v4()),
-        }];
+        let mut poisoned_lock = Lock::write("Entire Prod Cluster");
+        poisoned_lock.poison(&Uuid::new_v4());
+        let poisoned_locks = vec![poisoned_lock];
 
         let res = Scheduler::new(&tasks, &poisoned_locks, &[]).unwrap();
 
@@ -342,10 +341,9 @@ mod tests {
                 .with_write_lock("Entire Staging Cluster")
                 .build(),
         ];
-        let poisoned_locks = vec![Lock::Write {
-            name: "Entire Prod Cluster".to_string(),
-            poisoned: Some(Uuid::new_v4()),
-        }];
+        let mut poisoned_lock = Lock::write("Entire Prod Cluster");
+        poisoned_lock.poison(&Uuid::new_v4());
+        let poisoned_locks = vec![poisoned_lock];
 
         let res = Scheduler::new(&tasks, &poisoned_locks, &[]).unwrap();
 
@@ -361,10 +359,9 @@ mod tests {
             .with_display_name("I need to do something")
             .with_read_lock("Entire Prod Cluster")
             .build()];
-        let poisoned_locks = vec![Lock::Read {
-            name: "Entire Prod Cluster".to_string(),
-            poisoned: Some(Uuid::new_v4()),
-        }];
+        let mut poisoned_lock = Lock::read("Entire Prod Cluster");
+        poisoned_lock.poison(&Uuid::new_v4());
+        let poisoned_locks = vec![poisoned_lock];
 
         let res = Scheduler::new(&tasks, &poisoned_locks, &[]).unwrap();
 

--- a/vickyctl/src/cli.rs
+++ b/vickyctl/src/cli.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use uuid::Uuid;
+use vickylib::database::entities::task::TaskResult;
+use vickylib::database::entities::LockKind;
 
 // TODO: Add abouts to arguments
 #[derive(Parser, Debug, Clone)]
@@ -21,7 +23,7 @@ pub struct TaskData {
     #[clap(long)]
     pub lock_name: Vec<String>,
     #[clap(long)]
-    pub lock_type: Vec<String>,
+    pub lock_type: Vec<LockKind>,
     #[clap(long)]
     pub flake_url: String,
     #[clap(long)]
@@ -33,9 +35,9 @@ pub struct TaskData {
 #[derive(Subcommand, Debug)]
 pub enum TaskCommands {
     Create(TaskData),
-    // Logs, // TODO: could add this later
+    // TODO: Logs
     Claim { features: Vec<String> },
-    Finish { id: Uuid, status: String },
+    Finish { id: Uuid, status: TaskResult },
 }
 
 #[derive(Args, Debug)]

--- a/vickyctl/src/locks/types.rs
+++ b/vickyctl/src/locks/types.rs
@@ -1,51 +1,32 @@
-use serde::{Deserialize, Serialize};
-
 use crate::cli::LocksArgs;
 use crate::tasks::Task;
+use serde::{Deserialize, Serialize};
+use vickylib::database::entities::LockKind;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum PoisonedLock {
-    #[serde(rename = "WRITE")]
-    Write {
-        id: String,
-        name: String,
-        poisoned: Task,
-    },
-    #[serde(rename = "READ")]
-    Read {
-        id: String,
-        name: String,
-        poisoned: Task,
-    },
+pub struct PoisonedLock {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub kind: LockKind,
+    pub poisoned: Task,
 }
 
 impl PoisonedLock {
     pub fn id(&self) -> &str {
-        match self {
-            PoisonedLock::Write { id, .. } => id,
-            PoisonedLock::Read { id, .. } => id,
-        }
+        &self.id
     }
 
     pub fn name(&self) -> &str {
-        match self {
-            PoisonedLock::Write { name, .. } => name,
-            PoisonedLock::Read { name, .. } => name,
-        }
+        &self.name
     }
 
     pub fn get_poisoned_by(&self) -> &Task {
-        match self {
-            PoisonedLock::Write { poisoned, .. } => poisoned,
-            PoisonedLock::Read { poisoned, .. } => poisoned,
-        }
+        &self.poisoned
     }
 
     pub fn get_type(&self) -> &'static str {
-        match self {
-            PoisonedLock::Write { .. } => "WRITE",
-            PoisonedLock::Read { .. } => "READ",
-        }
+        self.kind.as_str()
     }
 }
 

--- a/vickyctl/src/main.rs
+++ b/vickyctl/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
         Cli::Task(task_args) => match task_args.commands {
             TaskCommands::Create(task_data) => create_task(&task_data, &task_args.ctx),
             TaskCommands::Claim { features } => claim_task(&features, &task_args.ctx),
-            TaskCommands::Finish { id, status } => finish_task(&id, &status, &task_args.ctx),
+            TaskCommands::Finish { id, status } => finish_task(&id, status, &task_args.ctx),
         },
         Cli::Tasks(tasks_args) => tasks::show_tasks(&tasks_args),
         Cli::Locks(locks_args) => tui::show_locks(&locks_args),

--- a/vickyctl/src/tui/lock_resolver.rs
+++ b/vickyctl/src/tui/lock_resolver.rs
@@ -233,7 +233,7 @@ fn draw_confirm_clear(
     };
     draw_centered_popup(
         f,
-        &format!("Do you really want to clear the lock {}?", lock.name()),
+        &format!("Do you really want to clear the lock {:?}?", lock.name()),
         button_select,
     );
 }


### PR DESCRIPTION
Putting String everywhere is extremely cursed because clap and these other libraries provide features when interacting with enums and concrete types. I also got rid of some more code duplication between the cli and the main server and worker by sharing the lib with everyone.